### PR TITLE
Change Generator to Reciever in azure provision file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ffc-doc-statement-receiver",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ffc-doc-statement-receiver",
-      "version": "1.0.7",
+      "version": "1.0.8",
       "license": "OGL-UK-3.0",
       "dependencies": {
         "@azure/identity": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffc-doc-statement-receiver",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Statement API",
   "homepage": "https://github.com/DEFRA/ffc-doc-statement-receiver",
   "main": "app/index.js",

--- a/provision.azure.yaml
+++ b/provision.azure.yaml
@@ -1,2 +1,2 @@
 resources:
-  identity: doc-statement-generator
+  identity: doc-statement-receiver


### PR DESCRIPTION
Making alterations to azure.provision.yaml, after mistakenly adding the wrong service name. 
